### PR TITLE
Make pip call more robust, for mixed Py2 and Py3 environments.

### DIFF
--- a/pip_autoremove.py
+++ b/pip_autoremove.py
@@ -80,7 +80,11 @@ def show_dist(dist):
 
 
 def remove_dist(dist):
-    subprocess.check_call(["pip", "uninstall", "-y", dist.project_name])
+    if sys.executable:
+        pip_cmd = [sys.executable, '-m', 'pip']
+    else:
+        pip_cmd = ['pip']
+    subprocess.check_call(pip_cmd + ["uninstall", "-y", dist.project_name])
 
 
 def get_graph():


### PR DESCRIPTION
Instead of harcoded `pip` executable name, attempt to invoke by its library module and keep it various python versions agnostic.

It is quite common to have multiple python versions installed in the system (Python 2.x, Python 3.x, PyPy, …) which also have different names for `pip` installer to prevent their mutual conflict, like `pip2, pip3, pip-pypy` etc. This patch fixes invalid behavior, when improper hardcoded name being used.